### PR TITLE
adds help if extension absent using vscodium

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 > **NOTE**: This theme includes a variant with italic keywords that looks great with fonts like Operator Mono or Catograph Mono
 
+## VSCodium
+*If using vscodium and Andromeda is not available as an extension see VSCodium.md*
+
 ## License
 
 [MIT](https://github.com/EliverLara/Andromeda/blob/master/LICENSE.md)

--- a/VSCodium.md
+++ b/VSCodium.md
@@ -1,0 +1,13 @@
+## VSCodium
+
+### If Andromeda is not an available extension in VSCodium, the theme can be made available as follows
+
+clone this repository
+```
+$ git clone https://github.com/EliverLara/Andromeda.git
+```
+move the ```Andromeda``` directory to your hidden VSCodium settings directory, in your home folder by default: 
+```
+$ mv Andromeda/ /home/username/.vscode-oss/extensions
+```
+Andromeda theme options will be available after restarting VSCodium 


### PR DESCRIPTION
If the extension isn't showing up when searching within the IDE this offers a way for VSCodium users to quickly install it