### PR TITLE
Improve sidebar contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.7.2] - 2023-01-24
+
+- Improve contrast in side bar colors
+
 ## [1.7.1] - 2022-05-16
 
 - Improve selection background color 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "andromeda",
     "displayName": "Andromeda",
     "description": "Dark theme with a taste of the universe",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "icon": "images/icon.png",
     "galleryBanner": {
         "color": "#23262E",

--- a/themes/Andromeda-color-theme-bordered.json
+++ b/themes/Andromeda-color-theme-bordered.json
@@ -54,7 +54,7 @@
         "sideBar.background": "#23262E",
         "sideBarSectionHeader.background": "#23262E",
         "sideBarTitle.foreground": "#00e8c6",
-        "sideBar.foreground": "#746f77",
+        "sideBar.foreground": "#999999",
         "sideBar.border": "#1B1D23",
         
         "editorGroup.background": "#23262E",
@@ -165,7 +165,10 @@
 
         "debugToolBar.background": "#20232A",
 
-        "walkThrough.embeddedEditorBackground": "#23262E"
+        "walkThrough.embeddedEditorBackground": "#23262E",
+
+        "gitDecoration.ignoredResourceForeground": "#555555"
+
     },
     "tokenColors": [
         {

--- a/themes/Andromeda-color-theme.json
+++ b/themes/Andromeda-color-theme.json
@@ -53,7 +53,7 @@
         "sideBar.background": "#23262E",
         "sideBarSectionHeader.background": "#23262E",
         "sideBarTitle.foreground": "#00e8c6",
-        "sideBar.foreground": "#746f77",
+        "sideBar.foreground": "#999999",
         
         "editorGroup.background": "#23262E",
         "editorGroup.dropBackground": "#495061d7",
@@ -163,7 +163,10 @@
 
         "debugToolBar.background": "#20232A",
 
-        "walkThrough.embeddedEditorBackground": "#23262E"
+        "walkThrough.embeddedEditorBackground": "#23262E",
+
+        "gitDecoration.ignoredResourceForeground": "#555555"
+
     },
     "tokenColors": [
         {

--- a/themes/Andromeda-italic-color-theme-bordered.json
+++ b/themes/Andromeda-italic-color-theme-bordered.json
@@ -54,7 +54,7 @@
 			"sideBar.background": "#23262E",
 			"sideBarSectionHeader.background": "#23262E",
 			"sideBarTitle.foreground": "#00e8c6",
-			"sideBar.foreground": "#746f77",
+			"sideBar.foreground": "#999999",
 			"sideBar.border": "#1B1D23",
 
 			"editorGroup.background": "#23262E",
@@ -165,7 +165,10 @@
 
 			"debugToolBar.background": "#20232A",
 
-			"walkThrough.embeddedEditorBackground": "#23262E"
+			"walkThrough.embeddedEditorBackground": "#23262E",
+
+			"gitDecoration.ignoredResourceForeground": "#555555"
+
 	},
 	"tokenColors": [
 			{

--- a/themes/Andromeda-italic-color-theme.json
+++ b/themes/Andromeda-italic-color-theme.json
@@ -53,7 +53,7 @@
 			"sideBar.background": "#23262E",
 			"sideBarSectionHeader.background": "#23262E",
 			"sideBarTitle.foreground": "#00e8c6",
-			"sideBar.foreground": "#746f77",
+			"sideBar.foreground": "#999999",
 
 			"editorGroup.background": "#23262E",
 			"editorGroup.dropBackground": "#495061d7",
@@ -163,7 +163,10 @@
 
 			"debugToolBar.background": "#20232A",
 
-			"walkThrough.embeddedEditorBackground": "#23262E"
+			"walkThrough.embeddedEditorBackground": "#23262E",
+
+			"gitDecoration.ignoredResourceForeground": "#555555"
+
 	},
 	"tokenColors": [
 			{


### PR DESCRIPTION
Resolves #28 

Adjusts default sidebar color as well as the color for the ignored Git context to have better contrast.

Please let me know if anything else is missing.