### PR TITLE
added better cmake syntax highlighting, cmake-tools package

### DIFF
--- a/themes/Andromeda-color-theme-bordered.json
+++ b/themes/Andromeda-color-theme-bordered.json
@@ -202,7 +202,8 @@
                 "constant.name.attribute.tag.jade",
                 "punctuation.definition.metadata.markdown",
                 "punctuation.definition.string.end.markdown",
-                "punctuation.definition.string.begin.markdown"
+                "punctuation.definition.string.begin.markdown",
+                "string.unquoted.cmake"
             ],
             "settings": {
                 "foreground": "#D5CED9"
@@ -303,7 +304,8 @@
                 "meta.link",
                 "meta.image",
                 "markup.italic",
-                "source.js support.type"
+                "source.js support.type",
+                "support.type"
                 
             ],
             "settings": {

--- a/themes/Andromeda-color-theme.json
+++ b/themes/Andromeda-color-theme.json
@@ -200,7 +200,8 @@
                 "constant.name.attribute.tag.jade",
                 "punctuation.definition.metadata.markdown",
                 "punctuation.definition.string.end.markdown",
-                "punctuation.definition.string.begin.markdown"
+                "punctuation.definition.string.begin.markdown",
+                "string.unquoted.cmake"
             ],
             "settings": {
                 "foreground": "#D5CED9"
@@ -301,7 +302,8 @@
                 "meta.link",
                 "meta.image",
                 "markup.italic",
-                "source.js support.type"
+                "source.js support.type",
+                "support.type"
                 
             ],
             "settings": {

--- a/themes/Andromeda-colorizer.json
+++ b/themes/Andromeda-colorizer.json
@@ -27,7 +27,8 @@
                 "constant.name.attribute.tag.jade",
                 "punctuation.definition.metadata.markdown",
                 "punctuation.definition.string.end.markdown",
-                "punctuation.definition.string.begin.markdown"
+                "punctuation.definition.string.begin.markdown",
+                "string.unquoted.cmake"
             ],
             "settings": {
                 "foreground": "#D5CED9"
@@ -127,7 +128,8 @@
                 "meta.link",
                 "meta.image",
                 "markup.italic",
-                "source.js support.type"
+                "source.js support.type",
+                "support.type"
             ],
             "settings": {
                 "foreground": "#c74ded"

--- a/themes/Andromeda-italic-color-theme-bordered.json
+++ b/themes/Andromeda-italic-color-theme-bordered.json
@@ -202,7 +202,8 @@
 							"constant.name.attribute.tag.jade",
 							"punctuation.definition.metadata.markdown",
 							"punctuation.definition.string.end.markdown",
-							"punctuation.definition.string.begin.markdown"
+							"punctuation.definition.string.begin.markdown",
+							"string.unquoted.cmake"
 					],
 					"settings": {
 							"foreground": "#D5CED9"
@@ -305,7 +306,8 @@
 							"meta.link",
 							"meta.image",
 							"markup.italic",
-							"source.js support.type"
+							"source.js support.type",
+							"support.type"
 
 					],
 					"settings": {

--- a/themes/Andromeda-italic-color-theme.json
+++ b/themes/Andromeda-italic-color-theme.json
@@ -200,7 +200,8 @@
 							"constant.name.attribute.tag.jade",
 							"punctuation.definition.metadata.markdown",
 							"punctuation.definition.string.end.markdown",
-							"punctuation.definition.string.begin.markdown"
+							"punctuation.definition.string.begin.markdown",
+							"string.unquoted.cmake"
 					],
 					"settings": {
 							"foreground": "#D5CED9"
@@ -303,7 +304,8 @@
 							"meta.link",
 							"meta.image",
 							"markup.italic",
-							"source.js support.type"
+							"source.js support.type",
+							"support.type"
 
 					],
 					"settings": {


### PR DESCRIPTION
After finding out that the poor syntax highlighting for `CMakeFiles` was for me a product of 1 out of date `cmake` extension. I decided that the overall styling of cmake files in Andromeda could be improved by adding tokens generated by the [cmake tools package](https://github.com/microsoft/vscode-cmake-tools) to the theme files, as otherwise most of it is parsed as a string and special cmake variables, flags and arguments like `VERSION` or `CMAKE_CXX_STANDARD` aren't coloured by Andromeda at all.

*(while technically all variables in cmakes are strings; if quoted and unquoted constant have the same colour,i think it makes CMakeFiles confusing and changes the overall theme from in comparison to most other file types in Andromeda)*

I'm going to look into writing a pull request on the cmake tools package to try and improve the cmake tokenising to include the `REQUIRED` flag and strings that only contain numerical values like `3.1.0`
# Example:
## Before
<img width="676" height="941" alt="image" src="https://github.com/user-attachments/assets/6fb8fb45-31a6-4c51-bf51-084b6a9c809b" />

## After
<img width="651" height="949" alt="image" src="https://github.com/user-attachments/assets/152a00b6-c2ff-4bdd-9a6f-b6db2a6234e6" />
